### PR TITLE
Add instructions to build to Heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:7
 
 ENV NODE_ENV development
+ENV PORT ${PORT:-3333}
 
-RUN npm set progress=false && npm install -g yarn
+RUN npm set progress=false
 
 RUN mkdir -p /usr/src/app
 
@@ -14,6 +15,9 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
 
 RUN yarn
+
+RUN npm rebuild node-sass
+RUN cd /usr/src/app/node_modules/nhsuk-frontend && npm run postinstall
 
 COPY ./ ./
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ as of yet.
 We are looking at using the TeamCity server at https://tc.nhschoices.net but
 at this point in time there doesn't seem to be a compelling case to move over.
 
+#### Deploy to Heroku
+
+```bash
+heroku plugins:install heroku-container-tools
+heroku plugins:install heroku-container-registry
+heroku container:login
+
+heroku create register-with-gp
+heroku config:set NODE_ENV=development --app register-with-gp
+heroku config:set SESSION_SECRET=secret_session_session --app register-with-gp
+heroku ps:scale web=1 --app register-with-gp
+heroku container:push web --app register-with-gp
+heroku open --app register-with-gp
+```
+
 ## License
 Short version: MIT
 Long version: see [LICENCE.txt](LICENSE.txt)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@ services:
   web:
     build: .
     ports:
-     - "3000:3000"
+     - "3333:3333"
     volumes:
      - ./:/usr/src/app

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-preset-stage-3": "^6.22.0",
     "css-loader": "^0.26.1",
     "eslint": "^3.15.0",
-    "extract-text-webpack-plugin": "beta",
+    "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "^0.10.0",
     "hapi-dev-error-page": "^0.0.1",
     "jest": "^18.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,15 +2035,9 @@ debug@2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.3.3:
+debug@2.3.3, debug@^2.1.1, debug@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
-  dependencies:
-    ms "0.7.2"
-
-debug@^2.1.1, debug@^2.2.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
 
@@ -2719,13 +2713,13 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extract-text-webpack-plugin@beta:
-  version "2.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.0.0-rc.3.tgz#7381aa7869ce26d4b39a7bab71cf09e5a38432b2"
+extract-text-webpack-plugin@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz#69315b885f876dbf96d3819f6a9f1cca7aebf159"
   dependencies:
     ajv "^4.11.2"
     async "^2.1.2"
-    loader-utils "^0.2.16"
+    loader-utils "^1.0.2"
     webpack-sources "^0.1.0"
 
 extsprintf@1.0.2:
@@ -4513,6 +4507,14 @@ loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.12, loader-utils@^0.
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.3.tgz#566c320c24c33cb3f02db4df83f3dbf60b253de3"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
 
 localtunnel@1.8.2:
   version "1.8.2"


### PR DESCRIPTION
 - update docker to fix dependencies
 - use dynamic port to support Heroku ports
 - update extract-text-webpack-plugin to 2.1.0

https://register-with-gp.herokuapp.com/start