### PR TITLE
Initial validation

### DIFF
--- a/src/client/js/index.js
+++ b/src/client/js/index.js
@@ -1,9 +1,11 @@
 const labelFocus = require('./modules/label-focus');
 const labelSelect = require('./modules/label-select');
+const errorSummary = require('./modules/error-summary');
 import title from './lib/title';
 
 labelFocus.init();
 labelSelect.init();
+errorSummary.init();
 title.init();
 
 if (module.hot) {

--- a/src/client/js/modules/error-summary.js
+++ b/src/client/js/modules/error-summary.js
@@ -1,0 +1,49 @@
+/* If the current page shows errors, set the focus to the error messages */
+const $ = require('jquery');
+
+const ErrorSummary = function () {
+  this.el = '.error-summary';
+};
+
+ErrorSummary.prototype.init = function() {
+  this.cacheEls();
+  this.bindEvents();
+  this.render();
+};
+
+ErrorSummary.prototype.cacheEls = function() {
+  this.$summary = $(this.el);
+};
+
+ErrorSummary.prototype.bindEvents = function() {
+  this.$summary.on('click', 'a', this.onErrorClick);
+};
+
+ErrorSummary.prototype.onErrorClick = function(event) {
+  event.preventDefault();
+
+  const $link = $(event.target);
+  const href = $link.attr('href');
+  const target = href.substr(href.indexOf('#'));
+  const $target = $(target);
+
+  if ($target.is(':input')) {
+    $target.focus();
+  } else {
+    $target.find(':input').first().focus();
+  }
+
+  $(document).scrollTop($target.offset().top);
+};
+
+ErrorSummary.prototype.render = function() {
+  if (this.$summary.length === 1) {
+    // If there is an error summary, set focus to the summary
+    this.$summary.focus();
+  } else {
+    // Otherwise, set focus to the field with the error
+    $('.error input:first').focus();
+  }
+};
+
+module.exports = new ErrorSummary();

--- a/src/client/styles/base.scss
+++ b/src/client/styles/base.scss
@@ -7,5 +7,6 @@
 @import "components/form-group";
 @import "components/form-textbox";
 @import "components/form-multiple-choice";
+@import "components/error-summary";
 @import "components/button";
 @import "components/summary";

--- a/src/client/styles/components/_error-summary.scss
+++ b/src/client/styles/components/_error-summary.scss
@@ -1,0 +1,27 @@
+.error-summary {
+  @include element-padding;
+  background-color: $red-10;
+  border-top: $baseline-grid-unit solid $red;
+
+  &:focus {
+    outline: 3px solid $yellow;
+  }
+}
+
+.error-summary__heading {
+  @include bold-font(24);
+}
+
+.error-summary__list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.error-summary__error-link {
+  &:link,
+  &:active,
+  &:hover,
+  &:visited {
+    color: darken($red, 10);
+  }
+}

--- a/src/client/styles/components/_form-label.scss
+++ b/src/client/styles/components/_form-label.scss
@@ -17,3 +17,9 @@
     margin-top: $baseline-grid-unit * 4;
   }
 }
+
+.form-label__error {
+  color: $red;
+  display: block;
+  font-weight: bold;
+}

--- a/src/client/styles/components/_form-multiple-choice.scss
+++ b/src/client/styles/components/_form-multiple-choice.scss
@@ -1,6 +1,6 @@
 // sass-lint:disable class-name-format nesting-depth
 
-$_border-colour: $grey-2;
+$_border-colour: $blue;
 $_border-width: 2px;
 $_element-size: 38px;
 $_radio-size: 20px;

--- a/src/client/styles/components/_form-textbox.scss
+++ b/src/client/styles/components/_form-textbox.scss
@@ -10,4 +10,8 @@
   &:focus {
     outline: 3px solid $yellow;
   }
+
+  &.has-error {
+    border-color: $red;
+  }
 }

--- a/src/client/styles/components/_form-textbox.scss
+++ b/src/client/styles/components/_form-textbox.scss
@@ -1,7 +1,7 @@
 .form-textbox {
   @include core-font(20);
   appearance: none;
-  border: ($baseline-grid-unit / 2) solid $grey-2;
+  border: ($baseline-grid-unit / 2) solid $blue;
   display: block;
   max-width: 540px;
   padding: $baseline-grid-unit;
@@ -14,4 +14,10 @@
   &.has-error {
     border-color: $red;
   }
+}
+
+textarea.form-textbox {
+  background-image: linear-gradient(to bottom, $grey-3 1px, transparent 1px);
+  background-repeat: repeat-y;
+  background-size: 100% $baseline-grid-unit * 8;
 }

--- a/src/server/plugins/register-form/steps/allergies.js
+++ b/src/server/plugins/register-form/steps/allergies.js
@@ -1,12 +1,13 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {id: 'allergies', label: 'Please enter your allergy details', type: 'textbox'},
-];
 
 const schema = Joi.object().keys({
-  'allergies': Joi.string().max(200),
+  'allergies': Joi.string().max(200).label('Allergies')
+    .meta({
+      componentType: 'textbox',
+      variant: 'large',
+    }),
   'submit': Joi.any().optional().strip()
 });
 
@@ -14,8 +15,8 @@ const title = 'Do you have any allergies?';
 const key = 'allergies';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -24,7 +25,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/common.js
+++ b/src/server/plugins/register-form/steps/common.js
@@ -37,17 +37,39 @@ export function validate(rawData, schemaDefinition) {
   });
 }
 
+export function getFieldData(schema) {
+  const fields = [];
+
+  _.each(schema._inner.children, (field) => {
+    const fieldData = {
+      id: field.key,
+      label: field.schema._flags.label,
+    };
+
+    _.each(field.schema._meta[0], (value, key) => {
+      fieldData[key] = value;
+    });
+
+    fields.push(fieldData);
+  });
+
+  return fields;
+}
+
 export function getHandlerFactory(
   key,
-  fields,
   title,
   schema,
   template = 'register-form/step') {
   return (request, reply) => {
     request.log(['cookie'], request.state.data);
     const stepData = _.get(request, `state.data.${key}`, {});
-    return reply
-      .view(template, {fields, stepData, title});
+
+    return reply.view(template, {
+      fields: getFieldData(schema),
+      stepData,
+      title,
+    });
   };
 }
 
@@ -77,7 +99,6 @@ export function dependsOnBoolean(step, path, toBe = true) {
 
 export function postHandlerFactory(
   key,
-  fields,
   title,
   schema,
   nextSteps,
@@ -103,8 +124,12 @@ export function postHandlerFactory(
           };
         });
 
-        return reply
-          .view(template, {fields, stepData: err._object, title, stepErrors});
+        return reply.view(template, {
+          fields: getFieldData(schema),
+          stepData: err._object,
+          title,
+          stepErrors,
+        });
       });
   };
 }

--- a/src/server/plugins/register-form/steps/common.js
+++ b/src/server/plugins/register-form/steps/common.js
@@ -10,7 +10,24 @@ const Joi = JoiBase
 
 export function validate(rawData, schemaDefinition) {
   return new Promise((resolve, reject) => {
-    Joi.validate(rawData, schemaDefinition, (err, value) => {
+    Joi.validate(rawData, schemaDefinition, {
+      abortEarly: false,
+      language: {
+        key: '{{!key}} ',
+        any: {
+          empty: 'cannot be blank',
+          required: '!!Please tell us {{!key}}',
+        },
+        base: {
+          number: 'must be a number',
+        },
+        string: {
+          min: 'must be at least {{limit}} characters',
+          max: 'must be less than {{limit}} characters',
+          length: 'must be {{limit}} characters',
+        },
+      },
+    }, (err, value) => {
       if (err) {
         reject(err);
       } else {
@@ -63,7 +80,8 @@ export function postHandlerFactory(
   fields,
   title,
   schema,
-  nextSteps) {
+  nextSteps,
+  template = 'register-form/step') {
   return (request, reply) => {
     // if form valid then redirect to next step
     validate(request.payload, schema)
@@ -76,8 +94,17 @@ export function postHandlerFactory(
       })
       .catch(err => {
         request.log(['error'], err);
+        const stepErrors = {};
+
+        _.each(err.details, (error) => {
+          stepErrors[error.path] = {
+            message: error.message,
+            label: error.context.key,
+          };
+        });
+
         return reply
-          .redirect(request.aka(`register-form:${key}`));
+          .view(template, {fields, stepData: err._object, title, stepErrors});
       });
   };
 }

--- a/src/server/plugins/register-form/steps/contact-email.js
+++ b/src/server/plugins/register-form/steps/contact-email.js
@@ -6,7 +6,7 @@ const fields = [
 ];
 
 const schema = Joi.object().keys({
-  'email': Joi.string().email().allow('').optional(),
+  'email': Joi.string().email().allow('').optional().label('Email'),
   'submit': Joi.any().optional().strip()
 });
 

--- a/src/server/plugins/register-form/steps/contact-email.js
+++ b/src/server/plugins/register-form/steps/contact-email.js
@@ -1,12 +1,8 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {id: 'email', label: 'Email', type: 'textbox'},
-];
-
 const schema = Joi.object().keys({
-  'email': Joi.string().email().allow('').optional().label('Email'),
+  'email': Joi.string().email().allow('').optional().label('Email').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip()
 });
 
@@ -14,8 +10,8 @@ const title = 'What is your email address?';
 const key = 'email';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -24,7 +20,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/contact-telephone.js
+++ b/src/server/plugins/register-form/steps/contact-telephone.js
@@ -1,12 +1,9 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {id: 'telephone', label: 'Telephone', type: 'textbox'},
-];
 
 const schema = Joi.object().keys({
-  'telephone': Joi.string().max(20).allow('').optional().label('Telephone'),
+  'telephone': Joi.string().max(20).allow('').optional().label('Telephone').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip()
 });
 
@@ -14,8 +11,8 @@ const title = 'What is your telephone number?';
 const key = 'telephone';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -24,7 +21,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/contact-telephone.js
+++ b/src/server/plugins/register-form/steps/contact-telephone.js
@@ -6,7 +6,7 @@ const fields = [
 ];
 
 const schema = Joi.object().keys({
-  'telephone': Joi.string().max(20).allow('').optional(),
+  'telephone': Joi.string().max(20).allow('').optional().label('Telephone'),
   'submit': Joi.any().optional().strip()
 });
 

--- a/src/server/plugins/register-form/steps/current-medication.js
+++ b/src/server/plugins/register-form/steps/current-medication.js
@@ -1,12 +1,12 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {id: 'medication', label: 'Current Medication', type: 'textbox'},
-];
-
 const schema = Joi.object().keys({
-  'medication': Joi.string().max(200),
+  'medication': Joi.string().max(200).label('Current medication')
+    .meta({
+      componentType: 'textbox',
+      variant: 'large',
+    }),
   'submit': Joi.any().optional().strip()
 });
 
@@ -14,8 +14,8 @@ const title = 'Are you taking any medication?';
 const key = 'medication';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -24,7 +24,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/date-of-birth.js
+++ b/src/server/plugins/register-form/steps/date-of-birth.js
@@ -1,16 +1,10 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {id: 'day', label: 'Day', type: 'textbox'},
-  {id: 'month', label: 'Month', type: 'textbox'},
-  {id: 'year', label: 'Year', type: 'textbox'}
-];
-
 const schema = Joi.object().keys({
-  'day': Joi.number().integer().min(1).max(31).required(),
-  'month': Joi.number().integer().min(1).max(12).required(),
-  'year': Joi.number().integer().min(1885).max(2025).required(),
+  'day': Joi.number().integer().min(1).max(31).required().label('Day').meta({ componentType: 'textbox' }),
+  'month': Joi.number().integer().min(1).max(12).required().label('Month').meta({ componentType: 'textbox' }),
+  'year': Joi.number().integer().min(1885).max(2025).required().label('Year').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip()
 });
 
@@ -18,8 +12,8 @@ const title = 'What is your date of birth?';
 const key = 'dateOfBirth';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -28,7 +22,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/home-address.js
+++ b/src/server/plugins/register-form/steps/home-address.js
@@ -17,7 +17,13 @@ const schema = Joi.object().keys({
   'address2': Joi.string().allow('').max(50),
   'address3': Joi.string().allow('').max(50),
   'locality': Joi.string().allow('').max(100).required(),
-  'postcode': Joi.postcode().uppercase(),
+  'postcode': Joi.postcode().uppercase().options({
+    language: {
+      string: {
+        regex: { base: 'must be a valid UK postcode' },
+      },
+    },
+  }).label('Post Code'),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');

--- a/src/server/plugins/register-form/steps/home-address.js
+++ b/src/server/plugins/register-form/steps/home-address.js
@@ -4,26 +4,18 @@ import {postHandlerFactory, getHandlerFactory} from './common';
 
 const Joi = JoiBase.extend(JoiPostcodeExtension);
 
-const fields = [
-  {id: 'address1', label: 'Address', type: 'textbox'},
-  {id: 'address2', label: '', type: 'textbox'},
-  {id: 'address3', label: '', type: 'textbox'},
-  {id: 'locality', label: 'Town or City', type: 'textbox'},
-  {id: 'postcode', label: 'Post Code', type: 'textbox'}
-];
-
 const schema = Joi.object().keys({
-  'address1': Joi.string().allow('').max(50),
-  'address2': Joi.string().allow('').max(50),
-  'address3': Joi.string().allow('').max(50),
-  'locality': Joi.string().allow('').max(100).required(),
+  'address1': Joi.string().allow('').max(50).label('Address').meta({ componentType: 'textbox' }),
+  'address2': Joi.string().allow('').max(50).meta({ componentType: 'textbox' }),
+  'address3': Joi.string().allow('').max(50).meta({ componentType: 'textbox' }),
+  'locality': Joi.string().allow('').max(100).required().label('Town or City').meta({ componentType: 'textbox' }),
   'postcode': Joi.postcode().uppercase().options({
     language: {
       string: {
         regex: { base: 'must be a valid UK postcode' },
       },
     },
-  }).label('Post Code'),
+  }).label('Post Code').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');
@@ -32,8 +24,8 @@ const title = 'What is your address?';
 const key = 'address';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -42,7 +34,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/index.js
+++ b/src/server/plugins/register-form/steps/index.js
@@ -26,8 +26,6 @@ import summaryStep from './summary';
  * @property {string} key - a unique ID for url-helpers like request.aka.
  * @property {string} title - Title of the page and what is asked to the user,
  * this is also slugified into the url for the page.
- * @property {[InputField]} fields - list of fields with data required.
- * @property {Array.<InputField>} fields - list of fields with data required.
  * @property {object} schema - a Joi schema to validate the supplied data
  * against.
  * @property {object} handlers - a GET and POST handler, typically created

--- a/src/server/plugins/register-form/steps/index.js
+++ b/src/server/plugins/register-form/steps/index.js
@@ -3,7 +3,7 @@ import dateOfBirthStep from './date-of-birth';
 import homeAddressStep from './home-address';
 import contactEmailStep from './contact-email';
 import contactTelephoneStep from './contact-telephone';
-import alreadyRegisteredWithGPStep from './current-gp';
+import previouslyRegisteredStep from './previously-registered';
 import previousAddressStep from './previous-address';
 import previousNameStep from './previous-name';
 import nhsNumberStep from './nhs-number';
@@ -48,7 +48,7 @@ const steps = [
   contactEmailStep,
   contactTelephoneStep,
   // armed forces?
-  alreadyRegisteredWithGPStep,
+  previouslyRegisteredStep,
   previousAddressStep,
   previousNameStep,
   nhsNumberStep,

--- a/src/server/plugins/register-form/steps/nhs-number.js
+++ b/src/server/plugins/register-form/steps/nhs-number.js
@@ -5,16 +5,16 @@ import {postHandlerFactory, getHandlerFactory} from './common';
 const Joi = JoiBase.extend(JoiNHSNumber);
 
 const fields = [
-  {id: 'nhsNumber', label: 'NHS Number', type: 'textbox'},
+  {id: 'nhs-number', label: '', type: 'textbox'},
 ];
 
 const schema = Joi.object().keys({
-  'nhsNumber': Joi.string().nhsnumber(),
+  'nhs-number': Joi.string().nhsnumber().options({ language: { string: { nhsnumber: '!!Please enter a valid NHS number' } } }),
   'submit': Joi.any().optional().strip(),
 });
 
 const title = 'What is your NHS Number?';
-const key = 'nhsNumber';
+const key = 'nhs-number';
 
 const handlers = {
   GET: getHandlerFactory(key, fields, title, schema),

--- a/src/server/plugins/register-form/steps/nhs-number.js
+++ b/src/server/plugins/register-form/steps/nhs-number.js
@@ -4,12 +4,8 @@ import {postHandlerFactory, getHandlerFactory} from './common';
 
 const Joi = JoiBase.extend(JoiNHSNumber);
 
-const fields = [
-  {id: 'nhs-number', label: '', type: 'textbox'},
-];
-
 const schema = Joi.object().keys({
-  'nhs-number': Joi.string().nhsnumber().options({ language: { string: { nhsnumber: '!!Please enter a valid NHS number' } } }),
+  'nhs-number': Joi.string().nhsnumber().options({ language: { string: { nhsnumber: '!!Please enter a valid NHS number' } } }).meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip(),
 });
 
@@ -17,8 +13,8 @@ const title = 'What is your NHS Number?';
 const key = 'nhs-number';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -27,7 +23,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/previous-address.js
+++ b/src/server/plugins/register-form/steps/previous-address.js
@@ -1,7 +1,7 @@
 import JoiBase from 'joi';
 import JoiPostcodeExtension from 'joi-postcode';
 import {postHandlerFactory, getHandlerFactory, dependsOnBoolean} from './common';
-import alreadyRegisteredWithAGPStep from './current-gp';
+import previouslyRegisteredStep from './previously-registered';
 
 const Joi = JoiBase.extend(JoiPostcodeExtension);
 
@@ -18,7 +18,13 @@ const schema = Joi.object().keys({
   'address2': Joi.string().allow('').max(50),
   'address3': Joi.string().allow('').max(50),
   'locality': Joi.string().allow('').max(100).required(),
-  'postcode': Joi.postcode().uppercase(),
+  'postcode': Joi.postcode().uppercase().options({
+    language: {
+      string: {
+        regex: { base: 'must be a valid UK postcode' },
+      },
+    },
+  }).label('Post Code'),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');
@@ -31,8 +37,7 @@ const handlers = {
   POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
 };
 
-const checkApplies = dependsOnBoolean(
-  alreadyRegisteredWithAGPStep, 'alreadyRegisteredWithGP');
+const checkApplies = dependsOnBoolean(previouslyRegisteredStep, 'previously-registered');
 
 /**
  * @type Step

--- a/src/server/plugins/register-form/steps/previous-address.js
+++ b/src/server/plugins/register-form/steps/previous-address.js
@@ -5,26 +5,18 @@ import previouslyRegisteredStep from './previously-registered';
 
 const Joi = JoiBase.extend(JoiPostcodeExtension);
 
-const fields = [
-  {id: 'address1', label: 'Address', type: 'textbox'},
-  {id: 'address2', label: '', type: 'textbox'},
-  {id: 'address3', label: '', type: 'textbox'},
-  {id: 'locality', label: 'Town or City', type: 'textbox'},
-  {id: 'postcode', label: 'Post Code', type: 'textbox'}
-];
-
 const schema = Joi.object().keys({
-  'address1': Joi.string().allow('').max(50),
-  'address2': Joi.string().allow('').max(50),
-  'address3': Joi.string().allow('').max(50),
-  'locality': Joi.string().allow('').max(100).required(),
+  'address1': Joi.string().allow('').max(50).label('Address').meta({ componentType: 'textbox' }),
+  'address2': Joi.string().allow('').max(50).meta({ componentType: 'textbox' }),
+  'address3': Joi.string().allow('').max(50).meta({ componentType: 'textbox' }),
+  'locality': Joi.string().allow('').max(100).required().label('Town or City').meta({ componentType: 'textbox' }),
   'postcode': Joi.postcode().uppercase().options({
     language: {
       string: {
         regex: { base: 'must be a valid UK postcode' },
       },
     },
-  }).label('Post Code'),
+  }).label('Post Code').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');
@@ -33,8 +25,8 @@ const title = 'Are you registered with a different address?';
 const key = 'previousAddress';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 const checkApplies = dependsOnBoolean(previouslyRegisteredStep, 'previously-registered');
@@ -44,7 +36,6 @@ const checkApplies = dependsOnBoolean(previouslyRegisteredStep, 'previously-regi
  */
 export default {
   title,
-  fields,
   schema,
   handlers,
   checkApplies

--- a/src/server/plugins/register-form/steps/previous-name.js
+++ b/src/server/plugins/register-form/steps/previous-name.js
@@ -1,5 +1,5 @@
 import Joi from 'joi';
-import alreadyRegisteredWithAGPStep from './current-gp';
+import previouslyRegisteredStep from './previously-registered';
 import {
   postHandlerFactory,
   getHandlerFactory,
@@ -13,9 +13,9 @@ const fields = [
 ];
 
 const schema = Joi.object().keys({
-  'first-name': Joi.string(),
+  'first-name': Joi.string().label('First name'),
   'middle-names': Joi.string().allow('').optional(),
-  'last-name': Joi.string(),
+  'last-name': Joi.string().label('Last name'),
   'submit': Joi.any().optional().strip()
 }).or('first-name', 'middle-names', 'last-name');
 
@@ -27,8 +27,7 @@ const handlers = {
   POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
 };
 
-const checkApplies = dependsOnBoolean(
-  alreadyRegisteredWithAGPStep, 'alreadyRegisteredWithGP');
+const checkApplies = dependsOnBoolean(previouslyRegisteredStep, 'previously-registered');
 
 /**
  * @type Step

--- a/src/server/plugins/register-form/steps/previous-name.js
+++ b/src/server/plugins/register-form/steps/previous-name.js
@@ -6,16 +6,10 @@ import {
   dependsOnBoolean
 } from './common';
 
-const fields = [
-  {id: 'first-name', label: 'First name', type: 'textbox'},
-  {id: 'middle-names', label: 'Middle names', type: 'textbox'},
-  {id: 'last-name', label: 'Last name', type: 'textbox'}
-];
-
 const schema = Joi.object().keys({
-  'first-name': Joi.string().label('First name'),
-  'middle-names': Joi.string().allow('').optional(),
-  'last-name': Joi.string().label('Last name'),
+  'first-name': Joi.string().label('First name').meta({ componentType: 'textbox' }),
+  'middle-names': Joi.string().allow('').optional().label('Middle names').meta({ componentType: 'textbox' }),
+  'last-name': Joi.string().label('Last name').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip()
 }).or('first-name', 'middle-names', 'last-name');
 
@@ -23,8 +17,8 @@ const title = 'Are you registered with a different name?';
 const key = 'previousName';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 const checkApplies = dependsOnBoolean(previouslyRegisteredStep, 'previously-registered');
@@ -35,7 +29,6 @@ const checkApplies = dependsOnBoolean(previouslyRegisteredStep, 'previously-regi
 export default {
   key,
   title,
-  fields,
   schema,
   handlers,
   checkApplies

--- a/src/server/plugins/register-form/steps/previously-registered.js
+++ b/src/server/plugins/register-form/steps/previously-registered.js
@@ -1,20 +1,21 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {
-    id: 'previously-registered',
-    label: '',
-    type: 'multiple-choice',
-    children: [
-      { label: 'Yes' },
-      { label: 'No' },
-    ],
-  },
-];
-
 const schema = Joi.object().keys({
-  'previously-registered': Joi.boolean().truthy('Yes').falsy('No').required().label('if you’re registered with a GP'),
+  'previously-registered': Joi.boolean().truthy('Yes').falsy('No').required()
+    .meta({
+      componentType: 'multiple-choice',
+      children: [
+        { label: 'Yes' },
+        { label: 'No' },
+      ],
+      variant: 'radio',
+    })
+    .options({
+      language: {
+        any: { required: '!!Please tell us if you’re registered with a GP' },
+      },
+    }),
   'submit': Joi.any().optional().strip()
 });
 
@@ -22,8 +23,8 @@ const title = 'Are you already registered with a GP?';
 const key = 'previouslyRegistered';
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -32,7 +33,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/previously-registered.js
+++ b/src/server/plugins/register-form/steps/previously-registered.js
@@ -3,7 +3,7 @@ import {postHandlerFactory, getHandlerFactory} from './common';
 
 const fields = [
   {
-    id: 'alreadyRegisteredWithGP',
+    id: 'previously-registered',
     label: '',
     type: 'multiple-choice',
     children: [
@@ -14,12 +14,12 @@ const fields = [
 ];
 
 const schema = Joi.object().keys({
-  'alreadyRegisteredWithGP': Joi.boolean().truthy('Yes').falsy('No').required(),
+  'previously-registered': Joi.boolean().truthy('Yes').falsy('No').required().label('if you’re registered with a GP'),
   'submit': Joi.any().optional().strip()
 });
 
 const title = 'Are you already registered with a GP?';
-const key = 'alreadyRegisteredWithGP';
+const key = 'previouslyRegistered';
 
 const handlers = {
   GET: getHandlerFactory(key, fields, title, schema),

--- a/src/server/plugins/register-form/steps/your-name.js
+++ b/src/server/plugins/register-form/steps/your-name.js
@@ -1,16 +1,10 @@
 import Joi from 'joi';
 import {postHandlerFactory, getHandlerFactory} from './common';
 
-const fields = [
-  {id: 'first-name', label: 'First name', type: 'textbox'},
-  {id: 'middle-names', label: 'Middle names', type: 'textbox'},
-  {id: 'last-name', label: 'Last name', type: 'textbox'}
-];
-
 const schema = Joi.object().keys({
-  'first-name': Joi.string().label('First name'),
-  'middle-names': Joi.string().allow('').optional(),
-  'last-name': Joi.string().label('Last name'),
+  'first-name': Joi.string().label('First name').meta({ componentType: 'textbox' }),
+  'middle-names': Joi.string().allow('').optional().label('Middle names').meta({ componentType: 'textbox' }),
+  'last-name': Joi.string().label('Last name').meta({ componentType: 'textbox' }),
   'submit': Joi.any().optional().strip()
 }).or('first-name', 'middle-names', 'last-name');
 
@@ -19,8 +13,8 @@ const key = 'name';
 
 
 const handlers = {
-  GET: getHandlerFactory(key, fields, title, schema),
-  POST: nextStep => postHandlerFactory(key, fields, title, schema, nextStep)
+  GET: getHandlerFactory(key, title, schema),
+  POST: nextStep => postHandlerFactory(key, title, schema, nextStep)
 };
 
 /**
@@ -29,7 +23,6 @@ const handlers = {
 export default {
   key,
   title,
-  fields,
   schema,
   handlers
 };

--- a/src/server/plugins/register-form/steps/your-name.js
+++ b/src/server/plugins/register-form/steps/your-name.js
@@ -8,9 +8,9 @@ const fields = [
 ];
 
 const schema = Joi.object().keys({
-  'first-name': Joi.string(),
+  'first-name': Joi.string().label('First name'),
   'middle-names': Joi.string().allow('').optional(),
-  'last-name': Joi.string(),
+  'last-name': Joi.string().label('Last name'),
   'submit': Joi.any().optional().strip()
 }).or('first-name', 'middle-names', 'last-name');
 

--- a/src/server/templates/_components/error-summary.njk
+++ b/src/server/templates/_components/error-summary.njk
@@ -1,0 +1,31 @@
+{##
+ # Family: Display
+ #
+ # @param {object|array} [children] An array or object of errors
+ #
+ # @return {string} HTML for error summary
+ #
+ # @example
+ #   {% component 'errory-summary', {
+ #     children:  [{'error-field': 'Error message'}]
+ #   } %}
+ #}
+{% if children %}
+  <div class="error-summary" role="group" tabindex="-1" aria-labelledby="error-summary-heading">
+    <h1 class="error-summary__heading" id="error-summary-heading">
+      There was a problem submitting this page
+    </h1>
+
+    {% if children %}
+      <ul class="error-summary__list">
+        {% for key, error in children -%}
+          <li class="error-summary__error">
+            <a href="#input-{{ key }}"  class="error-summary__error-link">
+              {{ error.message | safe }}
+            </a>
+          </li>
+        {%- endfor %}
+      </ul>
+    {% endif %}
+  </div>
+{% endif %}

--- a/src/server/templates/_components/form-multiple-choice.njk
+++ b/src/server/templates/_components/form-multiple-choice.njk
@@ -30,8 +30,8 @@
  #}
 {% set hintId = 'hint-' + name %}
 
-<fieldset>
-  {% if label %}
+<fieldset id="input-{{ name }}">
+  {% if label or hint or error %}
     <legend class="form-label" id="group-{{ name }}">
       {{ label }} {% if optional %}(optional){% endif %}
       {% if hint %}

--- a/src/server/templates/_components/form-textbox.njk
+++ b/src/server/templates/_components/form-textbox.njk
@@ -20,23 +20,26 @@
  #}
 {% set hintId = 'hint-' + name %}
 
-{% if label %}
+{% if label or error or hint %}
   <label for="input-{{ name }}" class="form-label">
     {{ label }} {% if optional %}(optional){% endif %}
     {% if hint %}
       <span class="form-label__hint" id="{{ hintId }}">{{ hint }}</span>
     {% endif %}
+    {% if error %}
+      <span class="form-label__error">{{ error | trim }}</span>
+    {% endif %}
   </label>
 {% endif %}
 
 {% if variant == 'large' %}
-  <textarea name="{{ name }}" id="input-{{ name }}" rows="4" class="form-textbox{{ ' error' if error }}">{{ value }}</textarea>
+  <textarea name="{{ name }}" id="input-{{ name }}" rows="4" class="form-textbox{{ ' has-error' if error }}">{{ value }}</textarea>
 {% else %}
   <input
     type="text"
     name="{{ name }}"
     id="input-{{ name }}"
-    class="form-textbox{{ ' error' if error }}"
+    class="form-textbox{{ ' has-error' if error }}"
     {% if value %}
       value="{{ value }}"
     {% endif %}

--- a/src/server/templates/_components/form-textbox.njk
+++ b/src/server/templates/_components/form-textbox.njk
@@ -33,7 +33,7 @@
 {% endif %}
 
 {% if variant == 'large' %}
-  <textarea name="{{ name }}" id="input-{{ name }}" rows="4" class="form-textbox{{ ' has-error' if error }}">{{ value }}</textarea>
+  <textarea name="{{ name }}" id="input-{{ name }}" rows="6" class="form-textbox{{ ' has-error' if error }}">{{ value }}</textarea>
 {% else %}
   <input
     type="text"

--- a/src/server/templates/email/registration-summary.njk
+++ b/src/server/templates/email/registration-summary.njk
@@ -33,7 +33,7 @@ Date of Birth:
 
 {{ render_multi_line('Telephone', data.telephone) }}
 
-{%- if data.alreadyRegisteredWithGP['alreadyRegisteredWithGP'] %}
+{%- if data.previouslyRegistered['previously-registered'] %}
   {{ render_multi_line('Previous registered dddress', data.previousAddress) }}
 
   {{ render_one_line('Previous registered name', data.previousName) }}

--- a/src/server/templates/register-form/step.njk
+++ b/src/server/templates/register-form/step.njk
@@ -14,7 +14,7 @@
           label: field.label,
           name: field.id,
           children: field.children,
-          error: '',
+          error: stepErrors[field.id].message | replace(stepErrors[field.id].label, ""),
           value: stepData[field.id]
         } %}
       {% endfor %}

--- a/src/server/templates/register-form/step.njk
+++ b/src/server/templates/register-form/step.njk
@@ -10,13 +10,16 @@
       {% component 'error-summary', { children: stepErrors } %}
 
       {% for field in fields %}
-        {% component 'form-' + field.type, {
-          label: field.label,
-          name: field.id,
-          children: field.children,
-          error: stepErrors[field.id].message | replace(stepErrors[field.id].label, ""),
-          value: stepData[field.id]
-        } %}
+        {% if field.componentType in ['textbox', 'multiple-choice'] %}
+          {% component 'form-' + field.componentType, {
+            label: field.label,
+            name: field.id,
+            children: field.children,
+            variant: field.variant,
+            error: stepErrors[field.id].message | replace(stepErrors[field.id].label, ""),
+            value: stepData[field.id]
+          } %}
+        {% endif %}
       {% endfor %}
 
       <div class="form-group">

--- a/src/server/templates/register-form/step.njk
+++ b/src/server/templates/register-form/step.njk
@@ -6,6 +6,9 @@
 
     <form method="post">
       <input type="hidden" name="csrf" value="{{csrf}}">
+
+      {% component 'error-summary', { children: stepErrors } %}
+
       {% for field in fields %}
         {% component 'form-' + field.type, {
           label: field.label,

--- a/src/server/templates/register-form/summary.njk
+++ b/src/server/templates/register-form/summary.njk
@@ -26,7 +26,7 @@
       {{ row('Address', data.address, true) }}
       {{ row('Email', data.email, true) }}
       {{ row('Telephone', data.telephone, true) }}
-      {% if data.alreadyRegisteredWithGP['alreadyRegisteredWithGP'] %}
+      {% if data.previouslyRegistered['previously-registered'] %}
         {{ row('Previous registered dddress', data.previousAddress, true) }}
         {{ row('Previous registered name', data.previousName) }}
       {% endif %}


### PR DESCRIPTION
This Pr adds basic step validation. 

It transforms the error object returned from Joi and sends the data back to the view. As well as that it sets the error messages for generic messages and custom messages for steps like _Already registered_.

It also adds the styles for the error summary component and updates some of the form element styles to match the prototype.

### What it looks like

#### Multiple fields per page

<img width="807" alt="screen shot 2017-03-16 at 14 43 21" src="https://cloud.githubusercontent.com/assets/3327997/24001823/0c1f2128-0a57-11e7-8bee-80923798e873.png">

#### Single field per page

<img width="804" alt="screen shot 2017-03-16 at 14 43 43" src="https://cloud.githubusercontent.com/assets/3327997/24001830/119f54c4-0a57-11e7-8a4c-0b4c3577d526.png">
