### PR TITLE
Don't double babel client js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,5 @@ build/Release
 node_modules
 /dist/
 /src/client/compiled/
-/src/client/webpack-assets.json
 /docs/architecture/diagrams/*.sequence.svg
 /.env

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
   "scripts": {
     "test": "jest",
     "dev": "nodemon --exec babel-node --watch src/server/ src/server/index.js",
-    "build": "npm run clean && webpack -p --config src/client/webpack.config.babel.js && babel src -d dist --copy-files --source-maps",
+    "build:babel": "babel src -d dist --ignore-files src/client --copy-files --source-maps",
+    "build:webpack": "webpack -p --config src/client/webpack.config.babel.js",
+    "build": "npm run clean && npm-run-all --parallel build:* && mkdir -p dist/client/compiled && cp -r src/client/compiled/ dist/client/",
     "lint:eslint": "DEBUG=eslint:cli-engine eslint .",
     "lint:editorconfig": "eclint check src/** README.md",
     "lint": "npm-run-all --parallel lint:*",

--- a/src/client/webpack.config.babel.js
+++ b/src/client/webpack.config.babel.js
@@ -14,7 +14,7 @@ export default {
   devtool: 'cheap-module-source-map',
   plugins: [
     new AssetsPlugin({
-      path: __dirname,
+      path: Path.join(__dirname, './compiled'),
       prettyPrint: true
     }),
     new ExtractTextPlugin('[name].[hash].css'),

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,7 +2,6 @@
 import Glue from 'glue';
 import Path from 'path';
 import Dotenv from 'dotenv';
-import webpackConfig from '../client/webpack.config.babel.js';
 import Hoek from 'hoek';
 Dotenv.config();
 
@@ -123,6 +122,7 @@ const manifest = {
 };
 
 if (env === 'development') {
+  const webpackConfig = require('../client/webpack.config.babel.js').default;
   Hoek.merge(manifest.registrations, [
     {
       plugin: {

--- a/src/server/plugins/nunjucks/index.js
+++ b/src/server/plugins/nunjucks/index.js
@@ -3,7 +3,7 @@ import Nunjucks from 'nunjucks';
 import fs from 'fs';
 import {formatDate} from './functions';
 
-const webpackAssetsPath = '../../../client/webpack-assets.json';
+const webpackAssetsPath = Path.resolve(__dirname, '../../../client/compiled/webpack-assets.json');
 const webpackAssets = require(webpackAssetsPath);
 
 const COMPONENTS_PATH = '_components/';


### PR DESCRIPTION
We were running client side js through babel twice:
- through webpack
- through babel-cli

This commit stops babel-cli from processing those files and just copies them
over verbatim using `cp`