### PR TITLE
Support short textbox fields

### DIFF
--- a/src/client/styles/components/_form-textbox.scss
+++ b/src/client/styles/components/_form-textbox.scss
@@ -21,3 +21,9 @@ textarea.form-textbox {
   background-repeat: repeat-y;
   background-size: 100% $baseline-grid-unit * 8;
 }
+
+.form-textbox--short {
+  @include media(tablet) {
+    width: 8em;
+  }
+}

--- a/src/server/plugins/register-form/steps/home-address.js
+++ b/src/server/plugins/register-form/steps/home-address.js
@@ -15,7 +15,7 @@ const schema = Joi.object().keys({
         regex: { base: 'must be a valid UK postcode' },
       },
     },
-  }).label('Post Code').meta({ componentType: 'textbox' }),
+  }).label('Post Code').meta({ componentType: 'textbox', variant: 'short' }),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');

--- a/src/server/plugins/register-form/steps/nhs-number-details.js
+++ b/src/server/plugins/register-form/steps/nhs-number-details.js
@@ -7,7 +7,7 @@ import nhsNumberStep from './nhs-number';
 const Joi = JoiBase.extend(JoiNHSNumber);
 
 const schema = Joi.object().keys({
-  'nhs-number': Joi.string().nhsnumber().label('NHS number').meta({ componentType: 'textbox' }),
+  'nhs-number': Joi.string().nhsnumber().label('NHS number').meta({ componentType: 'textbox', variant: 'short' }),
   'submit': Joi.any().optional().strip(),
 });
 

--- a/src/server/plugins/register-form/steps/previous-address.js
+++ b/src/server/plugins/register-form/steps/previous-address.js
@@ -16,7 +16,7 @@ const schema = Joi.object().keys({
         regex: { base: 'must be a valid UK postcode' },
       },
     },
-  }).label('Post Code').meta({ componentType: 'textbox' }),
+  }).label('Post Code').meta({ componentType: 'textbox', variant: 'short' }),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');

--- a/src/server/templates/_components/form-multiple-choice.njk
+++ b/src/server/templates/_components/form-multiple-choice.njk
@@ -48,7 +48,7 @@
       {% if variant == 'checkbox' %}
         {% set isSelected = (value and (inputValue in value)) %}
       {% else %}
-        {% set isSelected = (inputValue | string == value | string) %}
+        {% set isSelected = (inputValue | string == value | default('') | string) %}
       {% endif %}
 
       <label

--- a/src/server/templates/_components/form-textbox.njk
+++ b/src/server/templates/_components/form-textbox.njk
@@ -39,7 +39,7 @@
     type="text"
     name="{{ name }}"
     id="input-{{ name }}"
-    class="form-textbox{{ ' has-error' if error }}"
+    class="form-textbox{{ ' form-textbox--short' if variant == 'short' }}{{ ' has-error' if error }}"
     {% if value %}
       value="{{ value }}"
     {% endif %}


### PR DESCRIPTION
This adds support for shorter text boxes which help to indicate
when a smaller input is required, for example postcode.

It then applies the correct variant where it is required.