### PR TITLE
Ignore jQuery from greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,5 +95,10 @@
   "pre-commit": [
     "test",
     "lint"
-  ]
+  ],
+  "greenkeeper": {
+    "ignore": [
+      "jquery"
+    ]
+  }
 }


### PR DESCRIPTION
We use a specific version of jQuery because of our [browser support](https://github.com/nhsuk/betahealth/blob/develop/CONTRIBUTING.md#browser-support)
so we do not want greenkeeper to automatically update this
dependency.