### PR TITLE
Fail the build if coverage drops too low

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,14 @@ $ yarn run lint:eslint
 #### Coverage
 
 We want to keep coverage high and our test suite does output a coverage
-summary. We don't fail the build if coverage is below a certain % but we will
-do that in the future.
+summary. The build will fail if coverage drops below:
+
+* 75% of statements
+* 75% of lines
+* 70% of functions
+* 75% of statements
+
+This is a low bar and we aim to increase it as we write more code.
 
 You can see the coverage summary by running:
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,14 @@
   },
   "jest": {
     "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 45,
+        "functions": 70,
+        "lines": 75,
+        "statements": 75
+      }
+    },
     "rootDir": "src",
     "testEnvironment": "node",
     "coverageDirectory": "coverage",


### PR DESCRIPTION
We want to stop untested code being committed to the repository so we are going to
turn on code coverage minimum thresholds.