### PR TITLE
hapi-error plugin conditional for production

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -50,14 +50,6 @@ const manifest = {
     },
     {
       plugin: {
-        register: 'hapi-error',
-        options: {
-          templateName: 'error-page'
-        }
-      }
-    },
-    {
-      plugin: {
         register: 'vision',
         options: {}
       }
@@ -143,6 +135,17 @@ if (env === 'development') {
       plugin: {
         register: './plugins/dev-error-page',
         options: {},
+      }
+    }
+  ]);
+} else {
+  Hoek.merge(manifest.registrations, [
+    {
+      plugin: {
+        register: 'hapi-error',
+        options: {
+          templateName: 'error-page'
+        }
       }
     }
   ]);


### PR DESCRIPTION
This makes the Hapi-Error plugin only apply when not running in dev mode
which means that in dev mode a developer can see useful stack traces