### PR TITLE
practice comes from url instead of cookies

### DIFF
--- a/src/server/plugins/register-form/steps/summary.js
+++ b/src/server/plugins/register-form/steps/summary.js
@@ -58,7 +58,7 @@ export function summaryPostHandler(request, reply) {
   validate(request.payload, schema)
     .then(async () => {
       const data = _.get(request, 'state.data', {});
-      const practice = request.state.practice || '';
+      const practice = request.params.practice || '';
 
       const emailText = await renderTemplate(
         request.server.plugins.NunjucksConfig.nunjucksEnv,


### PR DESCRIPTION
On the summary page getting the practice was still from cookies. That should be coming from url.