### PR TITLE
Content fix - wallington-family-practice.njk

### DIFF
--- a/src/server/templates/practices/end/wallington-family-practice.njk
+++ b/src/server/templates/practices/end/wallington-family-practice.njk
@@ -56,7 +56,6 @@
     </div>  
   
 
-    <h2 class="heading-medium">After you show your documents</h2>
     <div class="reading-width">
       <p>Wait {{ CURRENT_PRACTICE.regdays }} days before making appointments at {{ practice.name | default('the GP practice') }} - this is how long it usually takes to be registered. {{ practice.name | default('The GP practice') }} will contact you if they need anything else from you.</p>
     </div>


### PR DESCRIPTION
Change based on '2i' content review - deleted H2 header (After you show your documents) because this won't make sense to users (applicants don't need to go to Wallington in person to show their documents).