### PR TITLE
Content fix to registered-address-details.js

### DIFF
--- a/src/server/plugins/register-form/steps/registered-address-details.js
+++ b/src/server/plugins/register-form/steps/registered-address-details.js
@@ -18,7 +18,7 @@ const schema = Joi.object().keys({
         regex: { base: 'must be a valid UK postcode' },
       },
     },
-  }).label('Post Code').meta({ componentType: 'textbox', variant: 'short' }),
+  }).label('Postcode').meta({ componentType: 'textbox', variant: 'short' }),
   'submit': Joi.any().optional().strip(),
 })
   .or('address1', 'address2', 'address3');


### PR DESCRIPTION
Change based on '2i' content review - changed text box label from 'Post Code' to 'Postcode' so it's consistent with content style (and also consistent with the error message).