### PR TITLE
Update default start page

### DIFF
--- a/src/server/templates/practices/start/default.njk
+++ b/src/server/templates/practices/start/default.njk
@@ -34,7 +34,7 @@
       <section class="callout callout--info">
         <div class="reading-with">
           <p>
-            Some GP practices only register patients who live in the local area. Check with <a href="{{ CURRENT_PRACTICE.contact.link }}">{{ CURRENT_PRACTICE.name }}</a> if you’re unsure.
+            Some GP practices only register people who live in the local area. Check with <a href="{{ CURRENT_PRACTICE.contact.link }}">{{ CURRENT_PRACTICE.name }}</a> if you’re unsure.
           </p>
           </div>
       </section>


### PR DESCRIPTION
Content change based on '2i' content review - changed "patients" to "people", because the users who are registering aren't necessarily currently getting treatment.