### PR TITLE
space replaced in housenumber

### DIFF
--- a/src/server/plugins/getaddressio/index.js
+++ b/src/server/plugins/getaddressio/index.js
@@ -10,9 +10,10 @@ const TIMEOUT = 10000;
 function getAddresses(postcode, housenumber = '', timeout=TIMEOUT) {
   return new Promise((resolve, reject) => {
     const cleaned = postcode.replace(/\s+/g, '').toLowerCase();
+    const cleanedhousenumber = housenumber.replace(' ', '%20');
     const request = https.get({
       host: process.env.POSTCODE_API_HOST,
-      path: `/v2/uk/${ cleaned }/${ housenumber }/?api-key=${ process.env.POSTCODE_API_KEY }&format=true`
+      path: `/v2/uk/${ cleaned }/${ cleanedhousenumber }/?api-key=${ process.env.POSTCODE_API_KEY }&format=true`
     }, function(response) {
       if (response.statusCode === 200 && response.statusMessage === 'OK') {
         let body = '';


### PR DESCRIPTION
If house number contains a space the remote call hung.
Space has been replaced to %20.
Other special characters tested. No errors.