### PR TITLE
removed housenumber from search if no result

### DIFF
--- a/src/server/plugins/getaddressio/index.js
+++ b/src/server/plugins/getaddressio/index.js
@@ -61,6 +61,9 @@ function addressLookupHandler(request, reply) {
 
   getAddresses(postcode, housenumber)
     .then(addresses => {
+      if(addresses.length === 0){
+        addresses = getAddresses(postcode, '');
+      }
       reply(addresses);
     })
     .catch(err => {


### PR DESCRIPTION
In case there is no search result a second search applied without house number.